### PR TITLE
Add default CORS policy for API

### DIFF
--- a/src/MesEnterprise.Api/Program.cs
+++ b/src/MesEnterprise.Api/Program.cs
@@ -76,6 +76,16 @@ builder.Services.AddApiVersioning(options =>
 
 builder.Services.AddProblemDetails();
 builder.Services.AddResponseCompression();
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("Default", policy =>
+    {
+        policy
+            .AllowAnyOrigin()
+            .AllowAnyHeader()
+            .AllowAnyMethod();
+    });
+});
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- register the default CORS policy so the API's middleware pipeline can invoke it safely

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_b_68ef3c8ba120833392702f8759f226c5