### PR TITLE
Add OA LDAP authentication endpoint

### DIFF
--- a/src/MesEnterprise.Api/Controllers/Auth/AuthController.cs
+++ b/src/MesEnterprise.Api/Controllers/Auth/AuthController.cs
@@ -29,4 +29,16 @@ public class AuthController : ControllerBase
 
         return Ok(result);
     }
+
+    [HttpPost("oa-login")]
+    public async Task<IActionResult> LoginWithOa([FromBody] OaLoginCommand command, CancellationToken cancellationToken)
+    {
+        var result = await _sender.Send(command, cancellationToken);
+        if (!result.Success)
+        {
+            return Unauthorized(result);
+        }
+
+        return Ok(result);
+    }
 }

--- a/src/MesEnterprise.Api/appsettings.Development.json
+++ b/src/MesEnterprise.Api/appsettings.Development.json
@@ -7,5 +7,11 @@
   },
   "ConnectionStrings": {
     "Oracle": "User Id=mes_dev;Password=MesDev123!;Data Source=VN_YNMESD_DEV"
+  },
+  "Ldap": {
+    "Server": "10.11.2.6",
+    "Port": 389,
+    "BaseDn": "DC=luxshare,DC=com,DC=cn",
+    "BindUserFormat": "uid={0},DC=luxshare,DC=com,DC=cn"
   }
 }

--- a/src/MesEnterprise.Api/appsettings.json
+++ b/src/MesEnterprise.Api/appsettings.json
@@ -25,5 +25,11 @@
   },
   "Plugins": {
     "Path": "plugins"
+  },
+  "Ldap": {
+    "Server": "10.11.2.6",
+    "Port": 389,
+    "BaseDn": "DC=luxshare,DC=com,DC=cn",
+    "BindUserFormat": "uid={0},DC=luxshare,DC=com,DC=cn"
   }
 }

--- a/src/MesEnterprise.Application/Common/Interfaces/IIdentityService.cs
+++ b/src/MesEnterprise.Application/Common/Interfaces/IIdentityService.cs
@@ -6,6 +6,7 @@ public interface IIdentityService
 {
     Task<User?> GetUserAsync(string userName, CancellationToken cancellationToken);
     Task<bool> ValidateCredentialsAsync(string userName, string password, CancellationToken cancellationToken);
+    Task<bool> ValidateOaCredentialsAsync(string userName, string password, CancellationToken cancellationToken);
     Task<IReadOnlyCollection<string>> GetRolesAsync(Guid userId, CancellationToken cancellationToken);
     Task<IReadOnlyCollection<string>> GetPermissionsAsync(Guid userId, CancellationToken cancellationToken);
 }

--- a/src/MesEnterprise.Application/Features/Authentication/OaLoginCommand.cs
+++ b/src/MesEnterprise.Application/Features/Authentication/OaLoginCommand.cs
@@ -1,0 +1,40 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FluentValidation;
+using MediatR;
+using MesEnterprise.Application.Common.Interfaces;
+using MesEnterprise.Shared.Responses;
+
+namespace MesEnterprise.Application.Features.Authentication;
+
+public record OaLoginCommand(string UserName, string Password) : IRequest<ApiResponse<bool>>;
+
+public class OaLoginCommandValidator : AbstractValidator<OaLoginCommand>
+{
+    public OaLoginCommandValidator()
+    {
+        RuleFor(x => x.UserName).NotEmpty().MaximumLength(128);
+        RuleFor(x => x.Password).NotEmpty().MinimumLength(6);
+    }
+}
+
+public class OaLoginCommandHandler : IRequestHandler<OaLoginCommand, ApiResponse<bool>>
+{
+    private readonly IIdentityService _identityService;
+
+    public OaLoginCommandHandler(IIdentityService identityService)
+    {
+        _identityService = identityService;
+    }
+
+    public async Task<ApiResponse<bool>> Handle(OaLoginCommand request, CancellationToken cancellationToken)
+    {
+        var isValid = await _identityService.ValidateOaCredentialsAsync(request.UserName, request.Password, cancellationToken);
+        if (!isValid)
+        {
+            return ApiResponse<bool>.Fail("Invalid credentials");
+        }
+
+        return ApiResponse<bool>.Ok(true, "OA login successful");
+    }
+}

--- a/src/MesEnterprise.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/src/MesEnterprise.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -33,6 +33,8 @@ public static class InfrastructureServiceCollectionExtensions
             options.Configuration = configuration.GetConnectionString("Redis") ?? "localhost:6379";
         });
 
+        services.Configure<LdapSettings>(configuration.GetSection("Ldap"));
+
         services.AddDbContextFactory<TenantCatalogDbContext>(options =>
         {
             options.UseOracle(configuration.GetConnectionString("TenantCatalog") ?? configuration.GetConnectionString("Oracle"));

--- a/src/MesEnterprise.Infrastructure/Identity/IdentityService.cs
+++ b/src/MesEnterprise.Infrastructure/Identity/IdentityService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,6 +10,8 @@ using MesEnterprise.Domain.Identity;
 using MesEnterprise.Infrastructure.Persistence;
 using System.Security.Cryptography;
 using Microsoft.AspNetCore.Cryptography.KeyDerivation;
+using Microsoft.Extensions.Options;
+using System.DirectoryServices;
 
 namespace MesEnterprise.Infrastructure.Identity;
 
@@ -16,11 +19,13 @@ public class IdentityService : IIdentityService
 {
     private readonly MesDbContext _dbContext;
     private readonly ILogger<IdentityService> _logger;
+    private readonly LdapSettings _ldapSettings;
 
-    public IdentityService(MesDbContext dbContext, ILogger<IdentityService> logger)
+    public IdentityService(MesDbContext dbContext, ILogger<IdentityService> logger, IOptions<LdapSettings> ldapOptions)
     {
         _dbContext = dbContext;
         _logger = logger;
+        _ldapSettings = ldapOptions.Value;
     }
 
     public async Task<User?> GetUserAsync(string userName, CancellationToken cancellationToken)
@@ -39,6 +44,35 @@ public class IdentityService : IIdentityService
         }
 
         return VerifyPassword(password, user.PasswordHash);
+    }
+
+    public Task<bool> ValidateOaCredentialsAsync(string userName, string password, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(userName) || string.IsNullOrWhiteSpace(password))
+        {
+            return Task.FromResult(false);
+        }
+
+        var path = BuildLdapPath();
+        if (string.IsNullOrEmpty(path))
+        {
+            _logger.LogWarning("LDAP path is not configured. Unable to validate OA credentials for user {UserName}.", userName);
+            return Task.FromResult(false);
+        }
+
+        var bindUser = string.Format(CultureInfo.InvariantCulture, _ldapSettings.BindUserFormat ?? "{0}", userName);
+
+        try
+        {
+            using var entry = new DirectoryEntry(path, bindUser, password);
+            _ = entry.NativeObject;
+            return Task.FromResult(true);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "LDAP authentication failed for user {UserName}.", userName);
+            return Task.FromResult(false);
+        }
     }
 
     public async Task<IReadOnlyCollection<string>> GetRolesAsync(Guid userId, CancellationToken cancellationToken)
@@ -80,5 +114,17 @@ public class IdentityService : IIdentityService
         var salt = RandomNumberGenerator.GetBytes(16);
         var hash = KeyDerivation.Pbkdf2(password, salt, KeyDerivationPrf.HMACSHA256, iterations, 32);
         return string.Join('.', iterations, Convert.ToBase64String(salt), Convert.ToBase64String(hash));
+    }
+
+    private string BuildLdapPath()
+    {
+        if (string.IsNullOrWhiteSpace(_ldapSettings.Server))
+        {
+            return string.Empty;
+        }
+
+        var portSegment = _ldapSettings.Port > 0 ? $":{_ldapSettings.Port}" : string.Empty;
+        var baseDnSegment = string.IsNullOrWhiteSpace(_ldapSettings.BaseDn) ? string.Empty : $"/{_ldapSettings.BaseDn}";
+        return $"LDAP://{_ldapSettings.Server}{portSegment}{baseDnSegment}";
     }
 }

--- a/src/MesEnterprise.Infrastructure/Identity/LdapSettings.cs
+++ b/src/MesEnterprise.Infrastructure/Identity/LdapSettings.cs
@@ -1,0 +1,9 @@
+namespace MesEnterprise.Infrastructure.Identity;
+
+public class LdapSettings
+{
+    public string Server { get; init; } = string.Empty;
+    public int Port { get; init; } = 389;
+    public string BaseDn { get; init; } = string.Empty;
+    public string? BindUserFormat { get; init; } = "{0}";
+}

--- a/src/MesEnterprise.Infrastructure/MesEnterprise.Infrastructure.csproj
+++ b/src/MesEnterprise.Infrastructure/MesEnterprise.Infrastructure.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Quartz" Version="3.10.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="7.5.1" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="7.5.1" />
+    <PackageReference Include="System.DirectoryServices" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\MesEnterprise.Application\MesEnterprise.Application.csproj" />


### PR DESCRIPTION
## Summary
- add an OA login endpoint that authenticates credentials against LDAP
- introduce LDAP settings and configuration support to the infrastructure layer
- wire up System.DirectoryServices dependency for LDAP connectivity

## Testing
- not run (dotnet CLI not available in container)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_690ee6dccae88333a45e2d4dd2796bae)